### PR TITLE
[fix] removed tilt on gyro for team page cards

### DIFF
--- a/src/components/team/memberCard.tsx
+++ b/src/components/team/memberCard.tsx
@@ -29,8 +29,6 @@ const MemberCard: React.FC<MemberCardProps> = ({
     <Tilt
       className={` ${styles.baseCard} ${className} mainCard h-[80vw] max-h-[300px] w-[80vw] max-w-[300px]`}
       tiltReverse={true}
-      gyroscope={true}
-      glareEnable={true}
     >
       <Image
         src={src}


### PR DESCRIPTION
### DONE
- removed tilt on gyro cuz it couldn't be customized
- glare removed cuz it was sharpening the edges

### TODO
- customize the default tilt axis only for mobile screen
- or remove tilt on click in mobile screen